### PR TITLE
Bug fix navigation

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -17,13 +17,13 @@
            <a class="nav-link smooth" routerLink="/blog">Blog</a>
          </li>
          <li class="nav-item">
-           <a class="nav-link smooth" href="#about-us">About us</a>
+           <a class="nav-link smooth" href="/about">About us</a>
          </li>
          <li class="nav-item">
-           <a class="nav-link smooth" href="#newsletter">Newsletter </a>
+           <a class="nav-link smooth" href="/newsletter">Newsletter </a>
          </li>
          <li class="nav-item">
-           <a class="nav-link smooth" href="#contact">Contact</a>
+           <a class="nav-link smooth" href="/contact">Contact</a>
          </li>
 
          <!-- REF: https://getbootstrap.com/docs/4.0/components/dropdowns/ -->

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -43,7 +43,7 @@
            </div>
          </li>
          <li class="nav-item">
-           <a class="nav-link smooth" href="#gallery">Gallery</a>
+           <a class="nav-link smooth" href="/gallery">Gallery</a>
          </li>
 
        </ul>


### PR DESCRIPTION
fixed `about`, `contact us`, `newsletter` and `gallery` header / navigation links. Replaced `#` with `/`